### PR TITLE
Add a basic-osc readme with known issue

### DIFF
--- a/basic-osc/README.md
+++ b/basic-osc/README.md
@@ -7,3 +7,9 @@ This is a template that sends and receives OSC messages.
 With arduino-esp32 2.X (the version currently available in mainline platformio), in conjunction to the xtensa toolchain 12.X, the receive function crashes.
 
 Please use pioarduino to be able to use arduino-esp32 3.X.
+
+This can be done by setting the platform and framework as follows in platformio.ini:
+
+[env:your-template]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+framework = arduino


### PR DESCRIPTION
This warns users that this template will fail with up-to-date vanilla platformio